### PR TITLE
fix binding to viewmodel issue

### DIFF
--- a/ZdfFlatUI/MyControls/StepBar/Implementation/StepBar.cs
+++ b/ZdfFlatUI/MyControls/StepBar/Implementation/StepBar.cs
@@ -24,10 +24,13 @@ namespace ZdfFlatUI
             get { return (int)GetValue(ProgressProperty); }
             set { SetValue(ProgressProperty, value); }
         }
-
+        
         public static readonly DependencyProperty ProgressProperty =
-            DependencyProperty.Register("Progress", typeof(int), typeof(StepBar), new PropertyMetadata(0, OnProgressChangedCallback, OnProgressCoerceValueCallback));
-
+            DependencyProperty.Register("Progress", typeof(int), typeof(StepBar), new FrameworkPropertyMetadata(0, OnProgressChangedCallback, OnProgressCoerceValueCallback) {
+                BindsTwoWayByDefault = true,
+                DefaultUpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged
+            });
+            
         private static object OnProgressCoerceValueCallback(DependencyObject d, object baseValue)
         {
             //不让Progress超出边界


### PR DESCRIPTION
通过后台代码可以修改Progress可以实现UI的更新，但是通过binding的方式，UI 就不更新了。所以增加了两个属性
                BindsTwoWayByDefault = true,
                DefaultUpdateSourceTrigger = UpdateSourceTrigger.PropertyChanged